### PR TITLE
chore: remove unsupported config from heft configs

### DIFF
--- a/pages/heft_configs/typescript_json.md
+++ b/pages/heft_configs/typescript_json.md
@@ -6,7 +6,6 @@ navigation_source: docs_nav
 
 ## Supported file paths
 
-- **common/config/heft/typescript.json**
 - **&lt;project folder&gt;/.heft/typescript.json**
 
 ## Template


### PR DESCRIPTION
This MR removed the *common/heft/typescript.json* documentation